### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,4 +26,4 @@ require (
 	google.golang.org/protobuf v1.36.1 // indirect
 )
 
-go 1.22
+go 1.22.0


### PR DESCRIPTION
CodeQL reports "Invalid Go toolchain" which prevents  githubs code scanning. This commit should fix the issue.